### PR TITLE
Parameterize program

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: curl -L -o /tmp/tflint.zip https://github.com/wata727/tflint/releases/download/v0.9.2/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
       - run:
           name: Check Terraform configurations with tflint
-          command: tflint
+          command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && tflint --ignore-rule=terraform_module_pinned_source && echo "√ $m") || exit 1 ; done
   lint_handler:
     environment:
       AWS_DEFAULT_REGION: us-east-1

--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ include the following in your root terraform module:
 
 ```
 module "example_self" {
-  source      = "github.com/GSA/grace-inventory/terraform"
-  source_file = "../../release/grace-inventory-lambda.zip"
+  source       = "github.com/GSA/grace-inventory/terraform"
+  source_file  = "../../release/grace-inventory-lambda.zip"
+  appenv       = "environment"
+  project_name = "your-project"
 }
 ```
 
@@ -165,14 +167,15 @@ See the [examples](terraform/examples) directory for more examples.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| accounts\_info | \(optional\) Determines which accounts to parse.  Can be "self", comma delimited list of Account IDs or an S3 URI containing JSON output of `aws organizations list-accounts`.  If empty, tries to query accounts with `organizations:ListAccounts` | string | `"self"` | no |
+| source\_file | \(optional\) full or relative path to zipped binary of lambda handler | string | `"../release/grace-inventory-lambda.zip"` | no |
 | appenv | \(optional\) The environment in which the script is running \(development \| test \| production\) | string | `"development"` | no |
+| project_name | \(required\) project name \(e.g. grace, fcs, fas, etc.\). Used as prefix for AWS S3 bucket name | string | `"grace"` | yes |
+| accounts\_info | \(optional\) Determines which accounts to parse.  Can be "self", comma delimited list of Account IDs or an S3 URI containing JSON output of `aws organizations list-accounts`.  If empty, tries to query accounts with `organizations:ListAccounts` | string | `"self"` | no |
 | master\_account\_id | \(optional\) Account ID of AWS Master Payer Account | string | `""` | no |
 | master\_role\_name | \(optional\) Role assumed by lambda function to query organizations in Master Payer account | string | `""` | no |
 | organizational\_units | \(optional\) comma delimited list of organizational units to query for accounts. If set it will only query accounts in those organizational units | string | `""` | no |
 | regions | \(optional\) Comma delimited list of AWS regions to inventory | string | `"us-east-1,us-east-2,us-west-1,us-west-2"` | no |
 | schedule\_expression | \(optional\) Cloudwatch schedule expression for when to run inventory | string | `"cron(5 3 ? * MON-FRI *)"` | no |
-| source\_file | \(optional\) full or relative path to zipped binary of lambda handler | string | `"../release/grace-inventory-lambda.zip"` | no |
 | tenant\_role\_name | \(optional\) Role assumed by lambda function to query tenant accounts | string | `"OrganizationAccountAccessRole"` | no |
 
 [top](#top)

--- a/terraform/backend.tfvars.example
+++ b/terraform/backend.tfvars.example
@@ -1,3 +1,0 @@
-bucket = "terraform-backend-bucket"
-
-key = "grace_inventory_lambda.tfstate"

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,11 +1,12 @@
 resource "aws_cloudwatch_event_rule" "cwe_rule" {
-  name                = "${local.app_name}"
+  name                = local.app_name
   description         = "Triggers GRACE service inventory reporting Lambda function according to schedule expression"
-  schedule_expression = "${var.schedule_expression}"
+  schedule_expression = var.schedule_expression
 }
 
 resource "aws_cloudwatch_event_target" "cwe_target" {
-  rule      = "${aws_cloudwatch_event_rule.cwe_rule.name}"
-  target_id = "${local.app_name}"
-  arn       = "${aws_lambda_function.lambda_function.arn}"
+  rule      = aws_cloudwatch_event_rule.cwe_rule.name
+  target_id = local.app_name
+  arn       = aws_lambda_function.lambda_function.arn
 }
+

--- a/terraform/examples/example-master.tf
+++ b/terraform/examples/example-master.tf
@@ -5,4 +5,7 @@ module "example_master" {
   source        = "github.com/GSA/grace-inventory/terraform"
   accounts_info = ""
   source_file   = "../../release/grace-inventory-lambda.zip"
+  appenv        = "development"
+  project_name  = "grace"
 }
+

--- a/terraform/examples/example-master.tf
+++ b/terraform/examples/example-master.tf
@@ -6,6 +6,5 @@ module "example_master" {
   accounts_info = ""
   source_file   = "../../release/grace-inventory-lambda.zip"
   appenv        = "development"
-  project_name  = "grace"
+  //project_name  = "grace"
 }
-

--- a/terraform/examples/example-mgmt-all.tf
+++ b/terraform/examples/example-mgmt-all.tf
@@ -8,4 +8,7 @@ module "example_mgmt_all" {
   master_account_id = "111111111111"
   master_role_name  = "AssumableRole"
   source_file       = "../../release/grace-inventory-lambda.zip"
+  appenv            = "development"
+  project_name      = "grace"
 }
+

--- a/terraform/examples/example-mgmt-all.tf
+++ b/terraform/examples/example-mgmt-all.tf
@@ -9,6 +9,5 @@ module "example_mgmt_all" {
   master_role_name  = "AssumableRole"
   source_file       = "../../release/grace-inventory-lambda.zip"
   appenv            = "development"
-  project_name      = "grace"
+  //project_name      = "grace"
 }
-

--- a/terraform/examples/example-self.tf
+++ b/terraform/examples/example-self.tf
@@ -1,6 +1,9 @@
 // The default behavior is to inventory only the account the lambda function
 // is installed in (i.e. accounts_info = "self"
 module "example_self" {
-  source      = "github.com/GSA/grace-inventory/terraform"
-  source_file = "../../release/grace-inventory-lambda.zip"
+  source       = "github.com/GSA/grace-inventory/terraform"
+  source_file  = "../../release/grace-inventory-lambda.zip"
+  appenv       = "development"
+  project_name = "grace"
 }
+

--- a/terraform/examples/example-self.tf
+++ b/terraform/examples/example-self.tf
@@ -1,9 +1,8 @@
 // The default behavior is to inventory only the account the lambda function
 // is installed in (i.e. accounts_info = "self"
 module "example_self" {
-  source       = "github.com/GSA/grace-inventory/terraform"
-  source_file  = "../../release/grace-inventory-lambda.zip"
-  appenv       = "development"
-  project_name = "grace"
+  source      = "github.com/GSA/grace-inventory/terraform"
+  source_file = "../../release/grace-inventory-lambda.zip"
+  appenv      = "development"
+  //project_name = "grace"
 }
-

--- a/terraform/examples/versions.tf
+++ b/terraform/examples/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "iam_role" {
-  name        = "${local.app_name}"
+  name        = local.app_name
   description = "Role for GRACE Inventory Lambda function"
 
   assume_role_policy = <<EOF
@@ -17,10 +17,11 @@ resource "aws_iam_role" "iam_role" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_policy" "iam_policy" {
-  name = "${local.app_name}"
+  name        = local.app_name
   description = "Policy to allow creating GRACE service inventory report"
 
   policy = <<EOF
@@ -100,9 +101,11 @@ resource "aws_iam_policy" "iam_policy" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "iam_role_policy_attachment" {
-  role       = "${aws_iam_role.iam_role.name}"
-  policy_arn = "${aws_iam_policy.iam_policy.arn}"
+  role       = aws_iam_role.iam_role.name
+  policy_arn = aws_iam_policy.iam_policy.arn
 }
+

--- a/terraform/kms.tf
+++ b/terraform/kms.tf
@@ -2,7 +2,7 @@ resource "aws_kms_key" "kms_key" {
   description             = "Key for GRACE service inventory reporting S3 bucket"
   deletion_window_in_days = 7
   enable_key_rotation     = "true"
-  depends_on              = ["aws_iam_role.iam_role"]
+  depends_on              = [aws_iam_role.iam_role]
 
   policy = <<EOF
 {
@@ -37,9 +37,11 @@ resource "aws_kms_key" "kms_key" {
   ]
 }
 EOF
+
 }
 
 resource "aws_kms_alias" "kms_alias" {
-  name = "alias/${local.app_name}"
-  target_key_id = "${aws_kms_key.kms_key.key_id}"
+  name          = "alias/${local.app_name}"
+  target_key_id = aws_kms_key.kms_key.key_id
 }
+

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,24 +1,24 @@
 resource "aws_lambda_function" "lambda_function" {
-  filename         = "${var.source_file}"
-  function_name    = "${local.app_name}"
+  filename         = var.source_file
+  function_name    = local.app_name
   description      = "Creates report of AWS Services in Organization accounts and saves to Excel spreadsheet in S3 bucket"
-  role             = "${aws_iam_role.iam_role.arn}"
+  role             = aws_iam_role.iam_role.arn
   handler          = "grace-inventory-lambda"
-  source_code_hash = "${filesha256(var.source_file)}"
-  kms_key_arn      = "${aws_kms_key.kms_key.arn}"
+  source_code_hash = filesha256(var.source_file)
+  kms_key_arn      = aws_kms_key.kms_key.arn
   runtime          = "go1.x"
   timeout          = 900
 
   environment {
     variables = {
-      accounts_info     = "${var.accounts_info}"
-      kms_key_id        = "${aws_kms_key.kms_key.key_id}"
-      master_role_name  = "${var.master_role_name}"
-      master_account_id = "${var.master_account_id}"
+      accounts_info     = var.accounts_info
+      kms_key_id        = aws_kms_key.kms_key.key_id
+      master_role_name  = var.master_role_name
+      master_account_id = var.master_account_id
       // organizational_units = "${organizational_units}"
-      regions          = "${var.regions}"
-      s3_bucket        = "${aws_s3_bucket.bucket.bucket}"
-      tenant_role_name = "${var.tenant_role_name}"
+      regions          = var.regions
+      s3_bucket        = aws_s3_bucket.bucket.bucket
+      tenant_role_name = var.tenant_role_name
     }
   }
 }
@@ -26,7 +26,8 @@ resource "aws_lambda_function" "lambda_function" {
 resource "aws_lambda_permission" "lambda_permission" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda_function.function_name}"
+  function_name = aws_lambda_function.lambda_function.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.cwe_rule.arn}"
+  source_arn    = aws_cloudwatch_event_rule.cwe_rule.arn
 }
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,15 +1,9 @@
-terraform {
-  backend "s3" {
-    region = "us-east-1"
-  }
+data "aws_caller_identity" "current" {
 }
-
-provider "aws" {}
-
-data "aws_caller_identity" "current" {}
 
 locals {
-  app_name       = "grace-${var.appenv}-inventory"
-  account_id     = "${data.aws_caller_identity.current.account_id}"
-  logging_bucket = "${"${var.appenv}" == "integration-testing" ? "grace-development-access-logs" : "grace-${var.appenv}-access-logs"}"
+  app_name       = "${var.project_name}-${var.appenv}-inventory"
+  account_id     = data.aws_caller_identity.current.account_id
+  logging_bucket = var.appenv == "integration-testing" ? "grace-development-access-logs" : "${var.project_name}-${var.appenv}-access-logs"
 }
+

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,19 +1,20 @@
 output "lambda_function_arn" {
-  value       = "${aws_lambda_function.lambda_function.arn}"
+  value       = aws_lambda_function.lambda_function.arn
   description = "The Amazon Resource Name (ARN) identifying the Lambda Function"
 }
 
 output "lambda_function_last_modified" {
-  value       = "${aws_lambda_function.lambda_function.last_modified}"
+  value       = aws_lambda_function.lambda_function.last_modified
   description = "The date this resource was last modified"
 }
 
 output "lambda_function_kms_key_arn" {
-  value       = "${aws_lambda_function.lambda_function.kms_key_arn}"
+  value       = aws_lambda_function.lambda_function.kms_key_arn
   description = "The ARN for the KMS encryption key"
 }
 
 output "s3_bucket_id" {
-  value       = "${aws_s3_bucket.bucket.id}"
+  value       = aws_s3_bucket.bucket.id
   description = "The name of the S3 bucket where inventry reports are saved"
 }
+

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${local.app_name}"
+  bucket        = local.app_name
   acl           = "private"
   force_destroy = true
 
@@ -8,14 +8,14 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   logging {
-    target_bucket = "${local.logging_bucket}"
+    target_bucket = local.logging_bucket
     target_prefix = "${local.app_name}-logs/"
   }
 
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${aws_kms_key.kms_key.arn}"
+        kms_master_key_id = aws_kms_key.kms_key.arn
         sse_algorithm     = "aws:kms"
       }
     }
@@ -31,6 +31,6 @@ resource "aws_s3_bucket" "bucket" {
   }
 
   tags = {
-    Name = "GRACE Inventory Report"
+    Name = "${upper(var.project_name)} Inventory Report"
   }
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,7 +1,0 @@
-master_account_id = "111111111111"
-
-master_role_name = "AssumableRole"
-
-regions = "us-east-1,us-east-2,us-west-1,us-west-2"
-
-tenant_role_name = "AssumableRole"

--- a/terraform/tests/integration_test.tf
+++ b/terraform/tests/integration_test.tf
@@ -15,10 +15,10 @@ module "integration_test" {
   // source            = "github.com/GSA/grace-inventory/terraform?ref=latest"
   source            = "../"
   accounts_info     = "self"
+  project_name      = "grace"
   appenv            = var.appenv
   master_account_id = var.master_account_id
   master_role_name  = var.master_role_name
   tenant_role_name  = var.tenant_role_name
   source_file       = "../../release/grace-inventory-lambda.zip"
 }
-

--- a/terraform/tests/integration_test.tf
+++ b/terraform/tests/integration_test.tf
@@ -4,19 +4,21 @@ terraform {
   }
 }
 
-provider "aws" {}
+provider "aws" {
+}
 
 // If the Lambda function is installed in a non-master/mgmt account, it can
 // list all accounts and inventory each one using the OrganizationAccessRole
 // if accounts_info = "" and master_account_id and master_role_name are set
 // and the roles are assumable by the Lambda function's IAM role
 module "integration_test" {
-  // source            = "github.com/GSA/grace-inventory-lambda/terraform?ref=latest"
+  // source            = "github.com/GSA/grace-inventory/terraform?ref=latest"
   source            = "../"
   accounts_info     = "self"
-  appenv            = "${var.appenv}"
-  master_account_id = "${var.master_account_id}"
-  master_role_name  = "${var.master_role_name}"
-  tenant_role_name  = "${var.tenant_role_name}"
+  appenv            = var.appenv
+  master_account_id = var.master_account_id
+  master_role_name  = var.master_role_name
+  tenant_role_name  = var.tenant_role_name
   source_file       = "../../release/grace-inventory-lambda.zip"
 }
+

--- a/terraform/tests/variables.tf
+++ b/terraform/tests/variables.tf
@@ -1,23 +1,24 @@
 variable "appenv" {
-  type        = "string"
+  type        = string
   description = "(optional) The environment in which the script is running (development | test | production)"
   default     = "integration-testing"
 }
 
 variable "tenant_role_name" {
-  type        = "string"
+  type        = string
   description = "(optional) Role assumed by lambda function to query tenant accounts"
   default     = "OrganizationAccountAccessRole"
 }
 
 variable "master_role_name" {
-  type        = "string"
+  type        = string
   description = "(optional) Role assumed by lambda function to query organizations in Master Payer account"
   default     = ""
 }
 
 variable "master_account_id" {
-  type        = "string"
+  type        = string
   description = "(optional) Account ID of AWS Master Payer Account"
   default     = ""
 }
+

--- a/terraform/tests/versions.tf
+++ b/terraform/tests/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,53 +1,60 @@
 variable "schedule_expression" {
-  type        = "string"
+  type        = string
   description = "(optional) Cloudwatch schedule expression for when to run inventory"
   default     = "cron(5 3 ? * MON-FRI *)"
 }
 
 variable "tenant_role_name" {
-  type        = "string"
+  type        = string
   description = "(optional) Role assumed by lambda function to query tenant accounts"
   default     = "OrganizationAccountAccessRole"
 }
 
 variable "master_role_name" {
-  type        = "string"
+  type        = string
   description = "(optional) Role assumed by lambda function to query organizations in Master Payer account"
   default     = ""
 }
 
 variable "regions" {
-  type        = "string"
+  type        = string
   description = "(optional) Comma delimited list of AWS regions to inventory"
   default     = "us-east-1,us-east-2,us-west-1,us-west-2"
 }
 
 variable "appenv" {
-  type        = "string"
+  type        = string
   description = "(optional) The environment in which the script is running (development | test | production)"
   default     = "development"
 }
 
 variable "master_account_id" {
-  type        = "string"
+  type        = string
   description = "(optional) Account ID of AWS Master Payer Account"
   default     = ""
 }
 
 variable "accounts_info" {
-  type        = "string"
+  type        = string
   description = "(optional) Determines which accounts to parse.  Can be \"self\", comma delimited list of Account IDs or an S3 URI containing JSON output of `aws organizations list-accounts`.  If empty, tries to query accounts with `organizations:ListAccounts`"
   default     = "self"
 }
 
 variable "organizational_units" {
-  type        = "string"
+  type        = string
   description = "(optional) comma delimited list of organizational units to query for accounts. If set it will only query accounts in those organizational units"
   default     = ""
 }
 
 variable "source_file" {
-  type        = "string"
+  type        = string
   description = "(optional) full or relative path to zipped binary of lambda handler"
   default     = "../release/grace-inventory-lambda.zip"
 }
+
+variable "project_name" {
+  type        = string
+  description = "(required) project name (e.g. grace, fcs, fas, etc.). Used as prefix for AWS S3 bucket name"
+  default     = "grace"
+}
+

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
- Adds `program_name` variable
- Uses program name to construct `local.app_name` and specify `local.logging_bucket`
- "grace" still hard coded in handler unit tests and spreadsheet name (i.e. `grace_inventory_2019-09-26.xlsx`)
- Ran `terraform 0.12upgrade` against all terraform for more consistent HCL syntax

Note:  Had to comment out `program_name` argument in examples because they are validating against the master branch