### PR TITLE
Tag & Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,15 @@ jobs:
       - run:
           name: Run Unit Tests
           command: make test_handler
+  release_handler:
+    docker:
+      - image: circleci/golang:latest
+    working_directory: /go/src/github.com/GSA/grace-inventory
+    steps:
+      - checkout
+      - run:
+          name: Release handler
+          command: make release_handler
 
 workflows:
   version: 2
@@ -53,3 +62,9 @@ workflows:
       - validate_terraform
       - lint_handler
       - test_handler
+      - release_handler:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: master

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ download the binary release from Github or compile the handler locally.
 ```bash
 mkdir -p release
 cd release
-curl -L https://github.com/GSA/grace-inventory/releases/download/v0.1.2/grace-inventory-lambda.zip -o grace-inventory-lambda.zip
+curl -L https://github.com/GSA/grace-inventory/releases/download/v0.1.3/grace-inventory-lambda.zip -o grace-inventory-lambda.zip
 cd ..
 ```
 
@@ -146,7 +146,7 @@ include the following in your root terraform module:
 
 ```
 module "example_self" {
-  source       = "github.com/GSA/grace-inventory?ref=v0.1.2"
+  source       = "github.com/GSA/grace-inventory?ref=v0.1.3"
   source_file  = "../../release/grace-inventory-lambda.zip"
   appenv       = "environment"
   project_name = "your-project"

--- a/examples/example-master.tf
+++ b/examples/example-master.tf
@@ -2,7 +2,7 @@
 // list all accounts and inventory each one using the OrganizationAccessRole
 // if accounts_info = ""
 module "example_master" {
-  source        = "github.com/GSA/grace-inventory?ref=v0.1.2"
+  source        = "github.com/GSA/grace-inventory?ref=v0.1.3"
   accounts_info = ""
   source_file   = "../../release/grace-inventory-lambda.zip"
   appenv        = "development"

--- a/examples/example-mgmt-all.tf
+++ b/examples/example-mgmt-all.tf
@@ -3,7 +3,7 @@
 // if accounts_info = "" and master_account_id and master_role_name are set
 // and the roles are assumable by the Lambda function's IAM role
 module "example_mgmt_all" {
-  source            = "github.com/GSA/grace-inventory?ref=v0.1.2"
+  source            = "github.com/GSA/grace-inventory?ref=v0.1.3"
   accounts_info     = ""
   master_account_id = "111111111111"
   master_role_name  = "AssumableRole"

--- a/examples/example-self.tf
+++ b/examples/example-self.tf
@@ -1,7 +1,7 @@
 // The default behavior is to inventory only the account the lambda function
 // is installed in (i.e. accounts_info = "self"
 module "example_self" {
-  source       = "github.com/GSA/grace-inventory?ref=v0.1.2"
+  source       = "github.com/GSA/grace-inventory?ref=v0.1.3"
   source_file  = "../../release/grace-inventory-lambda.zip"
   appenv       = "development"
   project_name = "grace"

--- a/handler/Makefile
+++ b/handler/Makefile
@@ -23,11 +23,8 @@ ifeq ($(strip $(GITHUB_TOKEN)),)
 else ifeq ($(strip $(CIRCLE_TAG)),)
 	@echo "CIRCLE_TAG must be set"
 	@exit 0
-else ifeq ($(shell echo $(CIRCLE_TAG) | egrep '^v\d+\.\d+\.\d+'),)
-	@echo "CIRCLE_TAG must match version pattern (i.e. v.1.2.3)"
-	@exit 0
 else
-	ghr -t $(GITHUB_TOKEN) -u $(CIRCLE_PROJECT_USERNAME) -r $(CIRCLE_PROJECT_REPONAME) -c $(CIRCLE_SHA1) -delete $(CIRCLE_TAG) $(RELEASEDIR)
+	ghr -u $(CIRCLE_PROJECT_USERNAME) -r $(CIRCLE_PROJECT_REPONAME) -c $(CIRCLE_SHA1) -delete $(CIRCLE_TAG) $(RELEASEDIR)
 endif
 
 clean:


### PR DESCRIPTION
- Adds release_handler job
- In theory, when this is pushed to master, the release_handler job will publish the binary as a release artifact using `ghr`.  I added a personal `GITHUB_TOKEN` environment variable to the CircleCI config.  This token should be for a service account, though.