### PR TITLE
Adds missing types to helpers.TypeToSheet (fixes: #39)

### DIFF
--- a/handler/helpers/ec2_test.go
+++ b/handler/helpers/ec2_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
@@ -79,6 +80,10 @@ func TestInstances(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Instances() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Images() ([]*ec2.Image, error)
@@ -91,6 +96,10 @@ func TestImages(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Images() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -105,6 +114,10 @@ func TestVolumes(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Volumes() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Snapshots() ([]*ec2.Snapshot, error)
@@ -117,6 +130,10 @@ func TestSnapshots(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Snapshots() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -131,6 +148,10 @@ func TestVpcs(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Vpcs() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Subnets() ([]*ec2.Subnet, error)
@@ -143,6 +164,10 @@ func TestSubnets(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Subnets() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -157,6 +182,10 @@ func TestSecurityGroups(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("SecurityGroups() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Addresses() ([]*ec2.Address, error)
@@ -170,6 +199,10 @@ func TestAddresses(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Addresses() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func KeyPairs() ([]*ec2.KeyPairInfo, error)
@@ -182,6 +215,10 @@ func TestKeyPairs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("KeyPairs() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 

--- a/handler/helpers/ec2_test.go
+++ b/handler/helpers/ec2_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
@@ -80,9 +79,9 @@ func TestInstances(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Instances() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -97,9 +96,9 @@ func TestImages(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Images() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -114,9 +113,9 @@ func TestVolumes(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Volumes() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -131,9 +130,9 @@ func TestSnapshots(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Snapshots() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -148,9 +147,9 @@ func TestVpcs(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Vpcs() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -165,9 +164,9 @@ func TestSubnets(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Subnets() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -182,9 +181,9 @@ func TestSecurityGroups(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("SecurityGroups() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -199,9 +198,9 @@ func TestAddresses(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Addresses() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -216,9 +215,9 @@ func TestKeyPairs(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("KeyPairs() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 

--- a/handler/helpers/helpers_test.go
+++ b/handler/helpers/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
@@ -107,6 +108,10 @@ func TestBuckets(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Buckets() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Stacks(svc *cloudformation.CloudFormationAPI) ([]*cloudformation.Stack, error)
@@ -119,6 +124,10 @@ func TestStacks(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Stacks() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -133,6 +142,10 @@ func TestAlarms(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Alarms() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func ConfigRules(svc *configservice.ConfigServiceAPI) ([]*configservice.ConfigRule, error)
@@ -146,6 +159,10 @@ func TestConfigRules(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("ConfigRules() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func LoadBalancers(svc *elbv2.ELBV2API) ([]*elbv2.LoadBalancer, error)
@@ -158,6 +175,10 @@ func TestLoadBalancers(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("LoadBalancers() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -233,7 +254,10 @@ func TestVaultsPagination(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Vaults() failed: %v", err)
 			}
-
+			_, err = inv.TypeToSheet(items)
+			if err != nil {
+				t.Fatalf("inv.TypeToSheet failed: %v", err)
+			}
 			length := len(items)
 			if length != tc.ExpectedLength {
 				t.Errorf("items length invalid, expected: %d, got: %d", tc.ExpectedLength, length)
@@ -264,6 +288,10 @@ func TestKeys(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Keys() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func DBInstances(cfg client.ConfigProvider, cred *credentials.Credentials) ([]*rds.DBInstance, error) {
@@ -271,9 +299,13 @@ func TestDBInstances(t *testing.T) {
 	svc := RDSSvc{
 		Client: mockedRDS{},
 	}
-	_, err := svc.DBInstances()
+	items, err := svc.DBInstances()
 	if err != nil {
 		t.Fatalf("DBInstances() failed: %v", err)
+	}
+	_, err = inv.TypeToSheet(items)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -282,9 +314,13 @@ func TestDBSnapshots(t *testing.T) {
 	svc := RDSSvc{
 		Client: mockedRDS{},
 	}
-	_, err := svc.DBSnapshots()
+	items, err := svc.DBSnapshots()
 	if err != nil {
 		t.Fatalf("DBSnapshots() failed: %v", err)
+	}
+	_, err = inv.TypeToSheet(items)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -293,9 +329,13 @@ func TestSecrets(t *testing.T) {
 	svc := SecretsManagerSvc{
 		Client: mockedSecretsManager{},
 	}
-	_, err := svc.Secrets()
+	items, err := svc.Secrets()
 	if err != nil {
 		t.Fatalf("Secrets() failed: %v", err)
+	}
+	_, err = inv.TypeToSheet(items)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -309,5 +349,9 @@ func TestParameters(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Parameters() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }

--- a/handler/helpers/helpers_test.go
+++ b/handler/helpers/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
@@ -108,9 +107,9 @@ func TestBuckets(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Buckets() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -125,9 +124,9 @@ func TestStacks(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Stacks() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -142,9 +141,9 @@ func TestAlarms(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Alarms() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -159,9 +158,9 @@ func TestConfigRules(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("ConfigRules() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -176,9 +175,9 @@ func TestLoadBalancers(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("LoadBalancers() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -254,9 +253,9 @@ func TestVaultsPagination(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Vaults() failed: %v", err)
 			}
-			_, err = inv.TypeToSheet(items)
+			_, err = TypeToSheet(items)
 			if err != nil {
-				t.Fatalf("inv.TypeToSheet failed: %v", err)
+				t.Fatalf("TypeToSheet failed: %v", err)
 			}
 			length := len(items)
 			if length != tc.ExpectedLength {
@@ -288,9 +287,9 @@ func TestKeys(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Keys() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -303,9 +302,9 @@ func TestDBInstances(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DBInstances() failed: %v", err)
 	}
-	_, err = inv.TypeToSheet(items)
+	_, err = TypeToSheet(items)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -318,9 +317,9 @@ func TestDBSnapshots(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DBSnapshots() failed: %v", err)
 	}
-	_, err = inv.TypeToSheet(items)
+	_, err = TypeToSheet(items)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -333,9 +332,9 @@ func TestSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Secrets() failed: %v", err)
 	}
-	_, err = inv.TypeToSheet(items)
+	_, err = TypeToSheet(items)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -350,8 +349,8 @@ func TestParameters(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Parameters() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }

--- a/handler/helpers/iam_test.go
+++ b/handler/helpers/iam_test.go
@@ -4,8 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GSA/grace-inventory-lambda/handler/inv"
-
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
@@ -45,9 +43,9 @@ func TestRoles(t *testing.T) {
 	if !reflect.DeepEqual(expected, roles) {
 		t.Errorf("Roles() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, roles, roles)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -62,9 +60,9 @@ func TestGroups(t *testing.T) {
 	if !reflect.DeepEqual(expected, groups) {
 		t.Errorf("Groups() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, groups, groups)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -79,9 +77,9 @@ func TestPolicies(t *testing.T) {
 	if !reflect.DeepEqual(expected, policies) {
 		t.Errorf("Policies() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, policies, policies)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -96,8 +94,8 @@ func TestUsers(t *testing.T) {
 	if !reflect.DeepEqual(expected, users) {
 		t.Errorf("Users() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, users, users)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }

--- a/handler/helpers/iam_test.go
+++ b/handler/helpers/iam_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GSA/grace-inventory-lambda/handler/inv"
+
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 )
@@ -43,6 +45,10 @@ func TestRoles(t *testing.T) {
 	if !reflect.DeepEqual(expected, roles) {
 		t.Errorf("Roles() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, roles, roles)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Groups() ([]*iam.Group, error)
@@ -55,6 +61,10 @@ func TestGroups(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, groups) {
 		t.Errorf("Groups() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, groups, groups)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }
 
@@ -69,6 +79,10 @@ func TestPolicies(t *testing.T) {
 	if !reflect.DeepEqual(expected, policies) {
 		t.Errorf("Policies() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, policies, policies)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Users() ([]*iam.User, error)
@@ -81,5 +95,9 @@ func TestUsers(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, users) {
 		t.Errorf("Users() failed. Expected: %#v (%T)\nGot: %#v (%T)", expected, expected, users, users)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }

--- a/handler/helpers/rds_test.go
+++ b/handler/helpers/rds_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
@@ -145,6 +146,10 @@ func TestRDSSvc_DBInstances(t *testing.T) {
 				t.Errorf("RDSSvc.DBInstances() error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
+			_, err = inv.TypeToSheet(got)
+			if err != nil {
+				t.Fatalf("inv.TypeToSheet failed: %v", err)
+			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("RDSSvc.DBInstances() = %v, want %v", got, tc.want)
 			}
@@ -241,6 +246,10 @@ func TestRDSSvc_DBSnapshots(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Errorf("RDSSvc.DBSnapshots() error = %v, wantErr %v", err, tc.wantErr)
 				return
+			}
+			_, err = inv.TypeToSheet(got)
+			if err != nil {
+				t.Fatalf("inv.TypeToSheet failed: %v", err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("RDSSvc.DBSnapshots() = %v, want %v", got, tc.want)

--- a/handler/helpers/rds_test.go
+++ b/handler/helpers/rds_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
@@ -146,9 +145,9 @@ func TestRDSSvc_DBInstances(t *testing.T) {
 				t.Errorf("RDSSvc.DBInstances() error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
-			_, err = inv.TypeToSheet(got)
+			_, err = TypeToSheet(got)
 			if err != nil {
-				t.Fatalf("inv.TypeToSheet failed: %v", err)
+				t.Fatalf("TypeToSheet failed: %v", err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("RDSSvc.DBInstances() = %v, want %v", got, tc.want)
@@ -247,9 +246,9 @@ func TestRDSSvc_DBSnapshots(t *testing.T) {
 				t.Errorf("RDSSvc.DBSnapshots() error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
-			_, err = inv.TypeToSheet(got)
+			_, err = TypeToSheet(got)
 			if err != nil {
-				t.Fatalf("inv.TypeToSheet failed: %v", err)
+				t.Fatalf("TypeToSheet failed: %v", err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("RDSSvc.DBSnapshots() = %v, want %v", got, tc.want)

--- a/handler/helpers/secretsmanager_test.go
+++ b/handler/helpers/secretsmanager_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
@@ -89,6 +90,10 @@ func TestSecretsManagerSvc_Secrets(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Errorf("EC2Svc.Secrets() error = %v, wantErr %v", err, tc.wantErr)
 				return
+			}
+			_, err = inv.TypeToSheet(got)
+			if err != nil {
+				t.Fatalf("inv.TypeToSheet failed: %v", err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("EC2Svc.Secrets() = %v, want %v", got, tc.want)

--- a/handler/helpers/secretsmanager_test.go
+++ b/handler/helpers/secretsmanager_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
@@ -91,9 +90,9 @@ func TestSecretsManagerSvc_Secrets(t *testing.T) {
 				t.Errorf("EC2Svc.Secrets() error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
-			_, err = inv.TypeToSheet(got)
+			_, err = TypeToSheet(got)
 			if err != nil {
-				t.Fatalf("inv.TypeToSheet failed: %v", err)
+				t.Fatalf("TypeToSheet failed: %v", err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("EC2Svc.Secrets() = %v, want %v", got, tc.want)

--- a/handler/helpers/sns_test.go
+++ b/handler/helpers/sns_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 )
@@ -38,9 +37,9 @@ func TestSubscriptions(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Subscriptions() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }
 
@@ -55,8 +54,8 @@ func TestTopics(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Topics() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
-	_, err = inv.TypeToSheet(expected)
+	_, err = TypeToSheet(expected)
 	if err != nil {
-		t.Fatalf("inv.TypeToSheet failed: %v", err)
+		t.Fatalf("TypeToSheet failed: %v", err)
 	}
 }

--- a/handler/helpers/sns_test.go
+++ b/handler/helpers/sns_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GSA/grace-inventory-lambda/handler/inv"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sns/snsiface"
 )
@@ -37,6 +38,10 @@ func TestSubscriptions(t *testing.T) {
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Subscriptions() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
 	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
+	}
 }
 
 // func Topics(cfg client.ConfigProvider, cred *credentials.Credentials) ([]*SnsTopic, error) {
@@ -49,5 +54,9 @@ func TestTopics(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, got) {
 		t.Errorf("Topics() failed.\nExpected %#v (%T)\nGot: %#v (%T)\n", expected, expected, got, got)
+	}
+	_, err = inv.TypeToSheet(expected)
+	if err != nil {
+		t.Fatalf("inv.TypeToSheet failed: %v", err)
 	}
 }

--- a/handler/inv/init.go
+++ b/handler/inv/init.go
@@ -4,52 +4,22 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/GSA/grace-inventory/handler/helpers"
 	"github.com/GSA/grace-inventory/handler/spreadsheet"
-)
-
-// Sheet name constants
-const (
-	SheetRoles          = "Roles"
-	SheetAccounts       = "Accounts"
-	SheetGroups         = "Groups"
-	SheetPolicies       = "Policies"
-	SheetUsers          = "Users"
-	SheetBuckets        = "Buckets"
-	SheetInstances      = "Instances"
-	SheetImages         = "Images"
-	SheetVolumes        = "Volumes"
-	SheetSnapshots      = "Snapshots"
-	SheetVpcs           = "VPCs"
-	SheetSubnets        = "Subnets"
-	SheetSecurityGroups = "SecurityGroups"
-	SheetAddresses      = "Addresses"
-	SheetKeyPairs       = "KeyPairs"
-	SheetStacks         = "Stacks"
-	SheetAlarms         = "Alarms"
-	SheetConfigRules    = "ConfigRules"
-	SheetLoadBalancers  = "LoadBlancers"
-	SheetVaults         = "Vaults"
-	SheetKeys           = "Keys"
-	SheetDBInstances    = "DBInstances"
-	SheetDBSnapshots    = "DBSnapshots"
-	SheetSecrets        = "Secrets"
-	SheetSubscriptions  = "Subscriptions"
-	SheetTopics         = "Topics"
-	SheetParameters     = "Parameters"
 )
 
 func init() {
 	accountsInfo := os.Getenv("accounts_info")
 	r := regexp.MustCompile(`^\d{12}`)
 	if accountsInfo == "self" || r.MatchString(accountsInfo) {
-		spreadsheet.RegisterSheet(SheetAccounts, func() *spreadsheet.Sheet {
+		spreadsheet.RegisterSheet(helpers.SheetAccounts, func() *spreadsheet.Sheet {
 			return &spreadsheet.Sheet{Name: "Accounts", Columns: []*spreadsheet.Column{
 				{FriendlyName: "Alias", FieldName: "Name"},
 				{FriendlyName: "Id", FieldName: "Id"},
 			}}
 		})
 	} else {
-		spreadsheet.RegisterSheet(SheetAccounts, func() *spreadsheet.Sheet {
+		spreadsheet.RegisterSheet(helpers.SheetAccounts, func() *spreadsheet.Sheet {
 			return &spreadsheet.Sheet{Name: "Accounts", Columns: []*spreadsheet.Column{
 				{FriendlyName: "Name", FieldName: "Name"},
 				{FriendlyName: "Id", FieldName: "Id"},
@@ -61,7 +31,7 @@ func init() {
 			}}
 		})
 	}
-	spreadsheet.RegisterSheet(SheetRoles, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetRoles, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "IAM Roles", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "RoleName", FieldName: "RoleName"},
@@ -70,7 +40,7 @@ func init() {
 			{FriendlyName: "CreateDate", FieldName: "CreateDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetGroups, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetGroups, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "IAM Groups", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "GroupName", FieldName: "GroupName"},
@@ -78,7 +48,7 @@ func init() {
 			{FriendlyName: "CreateDate", FieldName: "CreateDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetPolicies, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetPolicies, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "IAM Policies", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "PolicyName", FieldName: "PolicyName"},
@@ -86,7 +56,7 @@ func init() {
 			{FriendlyName: "CreateDate", FieldName: "CreateDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetUsers, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetUsers, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "IAM Users", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "UserName", FieldName: "UserName"},
@@ -94,14 +64,14 @@ func init() {
 			{FriendlyName: "CreateDate", FieldName: "CreateDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetBuckets, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetBuckets, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "S3 Buckets", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Name", FieldName: "Name"},
 			{FriendlyName: "CreateDate", FieldName: "CreationDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetInstances, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetInstances, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "EC2 Instances", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -114,7 +84,7 @@ func init() {
 			{FriendlyName: "LaunchTime", FieldName: "LaunchTime"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetImages, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetImages, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Images", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -126,7 +96,7 @@ func init() {
 			{FriendlyName: "CreationDate", FieldName: "CreationDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetVolumes, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetVolumes, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Volumes", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -138,7 +108,7 @@ func init() {
 			{FriendlyName: "CreateTime", FieldName: "CreateTime"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetSnapshots, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetSnapshots, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Snapshots", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -151,7 +121,7 @@ func init() {
 			{FriendlyName: "StartTime", FieldName: "StartTime"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetVpcs, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetVpcs, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "VPCs", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -162,7 +132,7 @@ func init() {
 			{FriendlyName: "DhcpOptionsId", FieldName: "DhcpOptionsId"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetSubnets, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetSubnets, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Subnets", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -174,7 +144,7 @@ func init() {
 			{FriendlyName: "AvailabilityZone", FieldName: "AvailabilityZone"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetSecurityGroups, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetSecurityGroups, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "SecurityGroups", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -184,7 +154,7 @@ func init() {
 			{FriendlyName: "VpcId", FieldName: "VpcId"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetAddresses, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetAddresses, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "EC2 IP Addresses", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -199,7 +169,7 @@ func init() {
 			{FriendlyName: "PublicIpv4Pool", FieldName: "PublicIpv4Pool"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetKeyPairs, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetKeyPairs, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Key Pairs", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -207,7 +177,7 @@ func init() {
 			{FriendlyName: "KeyFingerprint", FieldName: "KeyFingerprint"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetStacks, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetStacks, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "CloudFormation Stacks", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -226,7 +196,7 @@ func init() {
 			{FriendlyName: "TimeoutInMinutes", FieldName: "TimeoutInMinutes"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetAlarms, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetAlarms, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Alarms", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -253,7 +223,7 @@ func init() {
 			{FriendlyName: "Unit", FieldName: "Unit"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetConfigRules, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetConfigRules, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Config Rules", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -267,7 +237,7 @@ func init() {
 			{FriendlyName: "MaximumExecutionFrequency", FieldName: "MaximumExecutionFrequency"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetLoadBalancers, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetLoadBalancers, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Load Balancers", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -283,7 +253,7 @@ func init() {
 			{FriendlyName: "VpcId", FieldName: "VpcId"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetVaults, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetVaults, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Glacier Vaults", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -295,7 +265,7 @@ func init() {
 			{FriendlyName: "LastInventoryDate", FieldName: "LastInventoryDate"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetKeys, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetKeys, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "KMS Keys", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -316,7 +286,7 @@ func init() {
 			{FriendlyName: "ValidTo", FieldName: "ValidTo"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetDBInstances, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetDBInstances, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "RDS DB Instances", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -336,7 +306,7 @@ func init() {
 			{FriendlyName: "InstanceCreateTime", FieldName: "InstanceCreateTime"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetDBSnapshots, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetDBSnapshots, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "RDS DB Snapshots", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -359,7 +329,7 @@ func init() {
 			{FriendlyName: "VpcId", FieldName: "VpcId"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetSecrets, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetSecrets, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "Secrets", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -374,7 +344,7 @@ func init() {
 			{FriendlyName: "RotationEnabled", FieldName: "RotationEnabled"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetSubscriptions, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetSubscriptions, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "SNS Subscriptions", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -385,7 +355,7 @@ func init() {
 			{FriendlyName: "TopicArn", FieldName: "TopicArn"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetTopics, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetTopics, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "SNS Topics", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},
@@ -399,7 +369,7 @@ func init() {
 			{FriendlyName: "EffectiveDeliveryPolicy", FieldName: "EffectiveDeliveryPolicy"},
 		}}
 	})
-	spreadsheet.RegisterSheet(SheetParameters, func() *spreadsheet.Sheet {
+	spreadsheet.RegisterSheet(helpers.SheetParameters, func() *spreadsheet.Sheet {
 		return &spreadsheet.Sheet{Name: "SSM Parameters", Columns: []*spreadsheet.Column{
 			{FriendlyName: "Account", FieldName: ""},
 			{FriendlyName: "Region", FieldName: ""},

--- a/handler/inv/inv.go
+++ b/handler/inv/inv.go
@@ -1,10 +1,8 @@
 package inv
 
 import (
-	"errors"
 	"fmt"
 	"log"
-	"reflect"
 	"runtime"
 	"time"
 
@@ -150,32 +148,32 @@ func New() (*Inv, error) {
 	}
 	//store available queries for referencing
 	inv.queries = map[string]queryFunc{
-		SheetRoles:          inv.queryRoles,
-		SheetGroups:         inv.queryGroups,
-		SheetPolicies:       inv.queryPolicies,
-		SheetUsers:          inv.queryUsers,
-		SheetBuckets:        inv.queryBuckets,
-		SheetInstances:      inv.queryInstances,
-		SheetImages:         inv.queryImages,
-		SheetVolumes:        inv.queryVolumes,
-		SheetSnapshots:      inv.querySnapshots,
-		SheetVpcs:           inv.queryVpcs,
-		SheetSubnets:        inv.querySubnets,
-		SheetSecurityGroups: inv.querySecurityGroups,
-		SheetAddresses:      inv.queryAddresses,
-		SheetKeyPairs:       inv.queryKeyPairs,
-		SheetStacks:         inv.queryStacks,
-		SheetAlarms:         inv.queryAlarms,
-		SheetConfigRules:    inv.queryConfigRules,
-		SheetLoadBalancers:  inv.queryLoadBalancers,
-		SheetVaults:         inv.queryVaults,
-		SheetKeys:           inv.queryKeys,
-		SheetDBInstances:    inv.queryDBInstances,
-		SheetDBSnapshots:    inv.queryDBSnapshots,
-		SheetSecrets:        inv.querySecrets,
-		SheetSubscriptions:  inv.querySubscriptions,
-		SheetTopics:         inv.queryTopics,
-		SheetParameters:     inv.queryParameters,
+		helpers.SheetRoles:          inv.queryRoles,
+		helpers.SheetGroups:         inv.queryGroups,
+		helpers.SheetPolicies:       inv.queryPolicies,
+		helpers.SheetUsers:          inv.queryUsers,
+		helpers.SheetBuckets:        inv.queryBuckets,
+		helpers.SheetInstances:      inv.queryInstances,
+		helpers.SheetImages:         inv.queryImages,
+		helpers.SheetVolumes:        inv.queryVolumes,
+		helpers.SheetSnapshots:      inv.querySnapshots,
+		helpers.SheetVpcs:           inv.queryVpcs,
+		helpers.SheetSubnets:        inv.querySubnets,
+		helpers.SheetSecurityGroups: inv.querySecurityGroups,
+		helpers.SheetAddresses:      inv.queryAddresses,
+		helpers.SheetKeyPairs:       inv.queryKeyPairs,
+		helpers.SheetStacks:         inv.queryStacks,
+		helpers.SheetAlarms:         inv.queryAlarms,
+		helpers.SheetConfigRules:    inv.queryConfigRules,
+		helpers.SheetLoadBalancers:  inv.queryLoadBalancers,
+		helpers.SheetVaults:         inv.queryVaults,
+		helpers.SheetKeys:           inv.queryKeys,
+		helpers.SheetDBInstances:    inv.queryDBInstances,
+		helpers.SheetDBSnapshots:    inv.queryDBSnapshots,
+		helpers.SheetSecrets:        inv.querySecrets,
+		helpers.SheetSubscriptions:  inv.querySubscriptions,
+		helpers.SheetTopics:         inv.queryTopics,
+		helpers.SheetParameters:     inv.queryParameters,
 	}
 
 	sess, err := session.NewSession(&aws.Config{Region: &defaultRegion})
@@ -202,7 +200,7 @@ func New() (*Inv, error) {
 // until all queries have been ran and the spreadsheet has been saved to the bucket
 func (inv *Inv) Run(s *spreadsheet.Spreadsheet) error {
 	inv.spreadsheet = s
-	inv.query(map[string]queryFunc{SheetAccounts: inv.queryAccounts})
+	inv.query(map[string]queryFunc{helpers.SheetAccounts: inv.queryAccounts})
 
 	err := inv.aggregate()
 	if err != nil {
@@ -255,7 +253,7 @@ func (inv *Inv) aggregate() error {
 		case obj := <-inv.out:
 			switch val := obj.(type) {
 			case *spreadsheet.Payload:
-				sheet, err := TypeToSheet(val.Items)
+				sheet, err := helpers.TypeToSheet(val.Items)
 				if err != nil {
 					return err
 				}
@@ -264,7 +262,7 @@ func (inv *Inv) aggregate() error {
 					// stop processing further, we'll wait for the next one
 					break
 				}
-				if sheet == SheetAccounts {
+				if sheet == helpers.SheetAccounts {
 					// Use accounts to facilitate the creation of the credMgr
 					sess, err := inv.sessionMgr.Default()
 					if err != nil {
@@ -299,82 +297,6 @@ type stsSvc struct {
 // getCurrentIdentity ... returns the response from GetCallerIdentity
 func (svc *stsSvc) getCurrentIdentity() (*sts.GetCallerIdentityOutput, error) {
 	return svc.Client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-}
-
-// nolint: gocyclo
-// TypeToSheet ... converts a slice type to a sheet name
-func TypeToSheet(items interface{}) (string, error) {
-	var sheet string
-
-	s := reflect.ValueOf(items)
-	if s.Kind() != reflect.Slice {
-		return "", errors.New("items is not a sheet")
-	}
-
-	if s.Len() == 0 {
-		//Empty slice - this isn't an error, but we don't need to do anything
-		return "", nil
-	}
-	switch val := s.Index(0).Interface().(type) {
-	case *organizations.Account:
-		sheet = SheetAccounts
-	case *iam.Role:
-		sheet = SheetRoles
-	case *iam.Group:
-		sheet = SheetGroups
-	case *iam.Policy:
-		sheet = SheetPolicies
-	case *iam.User:
-		sheet = SheetUsers
-	case *s3.Bucket:
-		sheet = SheetBuckets
-	case *ec2.Instance:
-		sheet = SheetInstances
-	case *ec2.Image:
-		sheet = SheetImages
-	case *ec2.Volume:
-		sheet = SheetVolumes
-	case *ec2.Snapshot:
-		sheet = SheetSnapshots
-	case *ec2.Vpc:
-		sheet = SheetVpcs
-	case *ec2.Subnet:
-		sheet = SheetSubnets
-	case *ec2.SecurityGroup:
-		sheet = SheetSecurityGroups
-	case *ec2.Address:
-		sheet = SheetAddresses
-	case *ec2.KeyPairInfo:
-		sheet = SheetKeyPairs
-	case *cloudformation.Stack:
-		sheet = SheetStacks
-	case *cloudwatch.MetricAlarm:
-		sheet = SheetAlarms
-	case *configservice.ConfigRule:
-		sheet = SheetConfigRules
-	case *elbv2.LoadBalancer:
-		sheet = SheetLoadBalancers
-	case *glacier.DescribeVaultOutput:
-		sheet = SheetVaults
-	case *helpers.KmsKey:
-		sheet = SheetKeys
-	case *rds.DBInstance:
-		sheet = SheetDBInstances
-	case *rds.DBSnapshot:
-		sheet = SheetDBSnapshots
-	case *secretsmanager.SecretListEntry:
-		sheet = SheetSecrets
-	case *sns.Subscription:
-		sheet = SheetSubscriptions
-	case *helpers.SnsTopic:
-		sheet = SheetTopics
-	case *ssm.ParameterMetadata:
-		sheet = SheetParameters
-	default:
-		log.Printf("Unknown sheet type: %T", val)
-		return "", errors.New("unknown type")
-	}
-	return sheet, nil
 }
 
 // walkAccounts ... loops over all organization accounts, skipping suspended accounts, and calling 'fn'

--- a/handler/inv/inv.go
+++ b/handler/inv/inv.go
@@ -255,7 +255,7 @@ func (inv *Inv) aggregate() error {
 		case obj := <-inv.out:
 			switch val := obj.(type) {
 			case *spreadsheet.Payload:
-				sheet, err := typeToSheet(val.Items)
+				sheet, err := TypeToSheet(val.Items)
 				if err != nil {
 					return err
 				}
@@ -302,8 +302,8 @@ func (svc *stsSvc) getCurrentIdentity() (*sts.GetCallerIdentityOutput, error) {
 }
 
 // nolint: gocyclo
-// typeToSheet ... converts a slice type to a sheet name
-func typeToSheet(items interface{}) (string, error) {
+// TypeToSheet ... converts a slice type to a sheet name
+func TypeToSheet(items interface{}) (string, error) {
 	var sheet string
 
 	s := reflect.ValueOf(items)
@@ -352,6 +352,8 @@ func typeToSheet(items interface{}) (string, error) {
 		sheet = SheetAlarms
 	case *configservice.ConfigRule:
 		sheet = SheetConfigRules
+	case *elbv2.LoadBalancer:
+		sheet = SheetLoadBalancers
 	case *glacier.DescribeVaultOutput:
 		sheet = SheetVaults
 	case *helpers.KmsKey:

--- a/handler/main.go
+++ b/handler/main.go
@@ -6,39 +6,40 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GSA/grace-inventory/handler/helpers"
 	"github.com/GSA/grace-inventory/handler/inv"
 	"github.com/GSA/grace-inventory/handler/spreadsheet"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
 var defaultSheets = []string{
-	inv.SheetAccounts,
-	inv.SheetBuckets,
-	inv.SheetGroups,
-	inv.SheetImages,
-	inv.SheetInstances,
-	inv.SheetPolicies,
-	inv.SheetRoles,
-	inv.SheetSecurityGroups,
-	inv.SheetSnapshots,
-	inv.SheetSubnets,
-	inv.SheetUsers,
-	inv.SheetVolumes,
-	inv.SheetVpcs,
-	inv.SheetAddresses,
-	inv.SheetKeyPairs,
-	inv.SheetStacks,
-	inv.SheetAlarms,
-	inv.SheetConfigRules,
-	inv.SheetLoadBalancers,
-	inv.SheetVaults,
-	inv.SheetKeys,
-	inv.SheetDBInstances,
-	inv.SheetDBSnapshots,
-	inv.SheetSecrets,
-	inv.SheetSubscriptions,
-	inv.SheetTopics,
-	inv.SheetParameters,
+	helpers.SheetAccounts,
+	helpers.SheetBuckets,
+	helpers.SheetGroups,
+	helpers.SheetImages,
+	helpers.SheetInstances,
+	helpers.SheetPolicies,
+	helpers.SheetRoles,
+	helpers.SheetSecurityGroups,
+	helpers.SheetSnapshots,
+	helpers.SheetSubnets,
+	helpers.SheetUsers,
+	helpers.SheetVolumes,
+	helpers.SheetVpcs,
+	helpers.SheetAddresses,
+	helpers.SheetKeyPairs,
+	helpers.SheetStacks,
+	helpers.SheetAlarms,
+	helpers.SheetConfigRules,
+	helpers.SheetLoadBalancers,
+	helpers.SheetVaults,
+	helpers.SheetKeys,
+	helpers.SheetDBInstances,
+	helpers.SheetDBSnapshots,
+	helpers.SheetSecrets,
+	helpers.SheetSubscriptions,
+	helpers.SheetTopics,
+	helpers.SheetParameters,
 }
 
 func getSheets() []string {
@@ -50,14 +51,14 @@ func getSheets() []string {
 
 	// prune any references to 'Account' after index zero
 	for i := 0; i < len(sheets); i++ {
-		if i > 0 && sheets[i] == inv.SheetAccounts {
+		if i > 0 && sheets[i] == helpers.SheetAccounts {
 			sheets = append(sheets[:i], sheets[i+1:]...)
 		}
 	}
 
 	// ensure the first element is always 'Accounts'
-	if len(sheets) > 0 && sheets[0] != inv.SheetAccounts {
-		sheets = append([]string{inv.SheetAccounts}, sheets...)
+	if len(sheets) > 0 && sheets[0] != helpers.SheetAccounts {
+		sheets = append([]string{helpers.SheetAccounts}, sheets...)
 	}
 	return sheets
 }


### PR DESCRIPTION
- exports typeToSheet as TypeToSheet
- moves TypeToSheet to helpers package
- moves Sheet name constants to helpers package
- adds TypeToSheet test to all supported sheet types
- fixes bug where some types are not in typeToSheet causing reports to fail