### PR TITLE
adds the aws_s3_bucket_public_access_block for the inventory bucket

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -34,3 +34,12 @@ resource "aws_s3_bucket" "bucket" {
     Name = "${upper(var.project_name)} Inventory Report"
   }
 }
+
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
The inventory bucket was misconfigured as it was allowed to have public-facing files uploaded. This PR adds the necessary aws_s3_bucket_public_access_block and restricts this type of access.